### PR TITLE
SDKS-3634-Change logo - modify READMEs

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SuppressKotlinCodeStyleNotification">
+    <option name="disableForAll" value="true" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/sdk-sample-apps.iml" filepath="$PROJECT_DIR$/.idea/sdk-sample-apps.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/sdk-sample-apps.iml
+++ b/.idea/sdk-sample-apps.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>
@@ -9,24 +9,24 @@
 
 Ping provides these samples to help demonstrate SDK functionality/implementation. They are provided "as is" and are not official products of Ping and are not officially supported.
 
-### Integrate with PingOne Advanced Identity Cloud / PingAM:
+Our samples showcase functionality of our SDKs to get you up and running,
+whether you are using PingOne Advanced Identity Cloud,
+PingAM, OIDC Login, or PingOne DaVinci (coming soon), we've got you covered.
 
-We provide samples of integrating with PingOne Advanced Identity Cloud and PingAM for the following platforms:
+Explore the many use cases
+the Ping SDKs have to offer by referring to each respective SDK:
+
 - [JavaScript](./javascript/)
 
 - [iOS](./iOS/)
 
 - [Android](./android/)
 
-### Integrate with PingOne DaVinci:
-
-- Samples coming soon
-
 ## Documentation
 
 Detailed [documentation](https://docs.pingidentity.com/sdks/latest/sdks/index.html) is provided, and includes topics such as:
 
-- Introducing the SDK Features
+- Introducing the SDK features
 - Preparing your server for use with the SDKs
 - API Reference documentation
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>
@@ -9,7 +9,20 @@
 
 Ping provides these Android samples to help demonstrate SDK functionality/implementation. They are provided "as is" and are not official products of Ping and are not officially supported.
 
-### Integrate with PingOne Advanced Identity Cloud / PingAM:
+The Ping SDK for Android enables you to integrate your SPA with our services.
+There are two methods of UI integration:
+- Embedded - With this option, each app has to have its own login User Interface (UI).
+  When a user attempts to log in to your application or site, they authenticate directly within the currently used application instead of being directed to a centralized web application to authenticate the user.
+- OIDC Login - Often referred to as centralized login,
+  with this option you reuse a central UI
+  (such as hosted pages for PingOne Advanced Identity Cloud or the Login Widget for PingOne/PingOne DaVinci)
+  or your own web application for login requests in multiple apps and sites.
+  When a user attempts to log in to your application or site, they are redirected to a central login UI. After the user authenticates, they are redirected back to your application or site.
+
+The sample apps focus on embedded login,
+except where noted in the _OIDC Login_ section.
+
+### Integrate with Auth Journeys - PingOne Advanced Identity Cloud / PingAM:
 
 To try out the Ping Android SDK please look at one of our samples:
 
@@ -36,9 +49,21 @@ To try out the Ping Android SDK please look at one of our samples:
   (https://docs.pingidentity.com/sdks/latest/sdks/tutorials/android/index.html)
 
 
-### Integrate with PingOne:
+### Integrate with flows - PingOne DaVinci:
 
-- Samples coming soon
+- Coming soon
+
+### OIDC Login:
+
+- Coming soon
+
+## Documentation
+
+Detailed [documentation](https://docs.pingidentity.com/sdks/latest/sdks/index.html) is provided, and includes topics such as:
+
+- Introducing the SDK features
+- Preparing your server for use with the SDKs
+- API Reference documentation
 
 ## Requirements
 

--- a/android/java-authenticator/README.md
+++ b/android/java-authenticator/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/android/java-quickstart/README.md
+++ b/android/java-quickstart/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/android/java-ui-prototype/README.md
+++ b/android/java-ui-prototype/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/android/kotlin-central-login-oidc/README.md
+++ b/android/kotlin-central-login-oidc/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/android/kotlin-davinci/README.md
+++ b/android/kotlin-davinci/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/android/kotlin-quickstart/README.md
+++ b/android/kotlin-quickstart/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/android/kotlin-ui-prototype/README.md
+++ b/android/kotlin-ui-prototype/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>
@@ -9,7 +9,20 @@
 
 Ping provides these iOS samples to help demonstrate SDK functionality/implementation. They are provided "as is" and are not official products of Ping and are not officially supported.
 
-### Integrate with PingOne Advanced Identity Cloud / PingAM:
+The Ping SDK for iOS enables you to integrate your SPA with our services.
+There are two methods of UI integration:
+- Embedded - With this option, each app has to have its own login User Interface (UI).
+  When a user attempts to log in to your application or site, they authenticate directly within the currently used application instead of being directed to a centralized web application to authenticate the user.
+- OIDC Login - Often referred to as centralized login,
+  with this option you reuse a central UI
+  (such as hosted pages for PingOne Advanced Identity Cloud or the Login Widget for PingOne/PingOne DaVinci)
+  or your own web application for login requests in multiple apps and sites.
+  When a user attempts to log in to your application or site, they are redirected to a central login UI. After the user authenticates, they are redirected back to your application or site.
+
+The sample apps focus on embedded login,
+except where noted in the _OIDC Login_ section.
+
+### Integrate with Auth Journeys - PingOne Advanced Identity Cloud / PingAM:
 
 To try out the Ping iOS SDK please look at one of our samples:
 
@@ -34,12 +47,23 @@ To try out the Ping iOS SDK please look at one of our samples:
   (https://docs.pingidentity.com/sdks/latest/sdks/tutorials/ios/index.html)
 
 
-### Integrate with PingOne:
+### Integrate with flows - PingOne DaVinci:
 
 -  [**Davinci using SwiftUI - `/ios/swiftui-davinci`**](./swiftui-davinci/)
 
-    - An example iOS project written in Swift/SwiftUI making use of the SDK. The sample supports the OOTB DaVinci Login flow.
-    
+    - An example iOS project written in Swift/SwiftUI making use of the SDK. The sample supports the OOTB PingOne Sign on with Sessions DaVinci flow.
+   
+### OIDC Login:
+
+- Coming soon
+
+## Documentation
+
+Detailed [documentation](https://docs.pingidentity.com/sdks/latest/sdks/index.html) is provided, and includes topics such as:
+
+- Introducing the SDK features
+- Preparing your server for use with the SDKs
+- API Reference documentation
 
 ## Requirements
 

--- a/iOS/swiftui-davinci/README.md
+++ b/iOS/swiftui-davinci/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/iOS/swiftui-oidc/README.md
+++ b/iOS/swiftui-oidc/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/iOS/uikit-passkeys/README.md
+++ b/iOS/uikit-passkeys/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/ForgeRock/sdk-sample-apps">
-    <img src="https://cdn.forgerock.com/logo/interim/Logo-PingIdentity-ForgeRock-Hor-FullColor.svg" alt="Logo">
+    <img src="https://www.pingidentity.com/content/dam/picr/nav/Ping-Logo-2.svg" alt="Ping Identity Logo">
   </a>
   <hr/>
 </p>
@@ -8,6 +8,19 @@
 ## Samples
 
 Ping provides these samples to help demonstrate SDK functionality/implementation. They are provided "as is" and are not official products of Ping and are not officially supported.
+
+The Ping SDK for JavaScript enables you to integrate your SPA with our services.
+There are two methods of UI integration:
+- Embedded - With this option, each app has to have its own login User Interface (UI).
+When a user attempts to log in to your application or site, they authenticate directly within the currently used application instead of being directed to a centralized web application to authenticate the user.
+- OIDC Login - Often referred to as centralized login,
+  with this option you reuse a central UI
+  (such as hosted pages for PingOne Advanced Identity Cloud or the Login Widget for PingOne/PingOne DaVinci)
+  or your own web application for login requests in multiple apps and sites.
+When a user attempts to log in to your application or site, they are redirected to a central login UI. After the user authenticates, they are redirected back to your application or site.
+
+The sample apps focus on embedded login,
+except where noted in the _OIDC Login_ section. 
 
 ### Integrate with PingOne Advanced Identity Cloud / PingAM:
 
@@ -27,11 +40,11 @@ To try out the Ping JavaScript SDK please look at one of our samples:
   - Todo application that involves authentication and authorization of a user to post Todos with the `@forgerock/javascript-sdk` in Angular.
     The main branch includes many flavors of callbacks, including WebAuthN, embedded login, and social login.
 
-### Integrate with PingOne:
+### Integrate with flows - PingOne DaVinci:
 
  - Coming soon
 
-### Generic OIDC
+### OIDC Login:
 
 - [**Central login - `central-login-oidc`**](./central-login-oidc/README.md)
 
@@ -39,9 +52,9 @@ To try out the Ping JavaScript SDK please look at one of our samples:
 
 ## Documentation
 
-Documentation for the SDKs is provided on [ForgeRock Backstage](https://docs.pingidentity.com/sdks/latest/index.html), and includes topics such as:
+Detailed [documentation](https://docs.pingidentity.com/sdks/latest/sdks/index.html) is provided, and includes topics such as:
 
-- Introducing the SDK Features
+- Introducing the SDK features
 - Preparing your server for use with the SDKs
 - API Reference documentation
 

--- a/javascript/central-login-oidc/README.md
+++ b/javascript/central-login-oidc/README.md
@@ -1,6 +1,7 @@
-# Central login OIDC
+# OIDC Login
 
-The SDK provides an option for using the Authorization Code Flow (with PKCE) with a centralized login application.
+The SDK provides an option for using the Authorization Code Flow
+(with PKCE) with a centralized application using OIDC Login. 
 
 For a non-authenticated user, use the `login: redirect` parameter of the `TokenManager` class to request OAuth/OIDC tokens. 
 


### PR DESCRIPTION
Initial PR to update the Logos in the README files to not point to one displaying ForgeRock.

Updated READMEs to be more consistent, added a section for OIDC Login, and added a blurb at the top of each read me about embedded versus OIDC as this is a question from the field.