### PR TITLE
Add e2e tests for oidc client central login sample app

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
           cd ../reactjs-todo-davinci && npm run e2e -- --shard=${{ matrix.shardIndex }}/4
           cd ../angular-todo && npm run e2e -- --shard=${{ matrix.shardIndex }}/4
           cd ../angular-todo-davinci && npm run e2e -- --shard=${{ matrix.shardIndex }}/4
+          cd ../central-login-oidc-new && npm run e2e -- --shard=${{ matrix.shardIndex }}/4
         env:
           REST_OAUTH_SECRET: ${{ secrets.REST_OAUTH_SECRET }}
 
@@ -59,3 +60,5 @@ jobs:
             ./javascript/reactjs-todo-davinci/playwright-report
             ./javascript/angular-todo-davinci/test-results
             ./javascript/angular-todo-davinci/playwright-report
+            ./javascript/central-login-oidc-new/test-results
+            ./javascript/central-login-oidc-new/playwright-report

--- a/javascript/central-login-oidc-new/.env.example
+++ b/javascript/central-login-oidc-new/.env.example
@@ -1,3 +1,4 @@
+VITE_PORT=8443
 VITE_SCOPE=$SCOPE # For PingOne servers, the `revoke` scope must be set as well.
 VITE_TIMEOUT=$TIMEOUT
 VITE_WEB_OAUTH_CLIENT=$WEB_OAUTH_CLIENT

--- a/javascript/central-login-oidc-new/e2e/login.spec.js
+++ b/javascript/central-login-oidc-new/e2e/login.spec.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+import { test, expect } from '@playwright/test';
+import { asyncEvents } from './utils/async-events';
+import {
+  pingAmUsername,
+  pingAmPassword,
+  pingOneUsername,
+  pingOnePassword,
+} from './utils/demo-users';
+
+test.describe('Login Tests', () => {
+  test('PingAM redirect login with valid credentials', async ({ page }) => {
+    const { navigate, clickButton } = asyncEvents(page);
+    await navigate('http://localhost:8444/');
+    expect(page.url()).toBe('http://localhost:8444/');
+
+    await clickButton('Login', 'https://openam-sdks.forgeblocks.com/');
+
+    await page.getByLabel('User Name').fill(pingAmUsername);
+    await page.getByRole('textbox', { name: 'Password' }).fill(pingAmPassword);
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await page.waitForURL('http://localhost:8444/**');
+    expect(page.url()).toContain('code');
+    expect(page.url()).toContain('state');
+    await expect(page.locator('#User pre')).toContainText('Sdk User');
+    await expect(page.locator('#User pre')).toContainText('sdkuser@example.com');
+  });
+
+  test('PingOne redirect login with valid credentials', async ({ page }) => {
+    const { navigate, clickButton } = asyncEvents(page);
+    await navigate('http://localhost:8443/');
+    expect(page.url()).toBe('http://localhost:8443/');
+
+    await clickButton('Login', 'https://apps.pingone.ca/');
+
+    await page.getByLabel('Username').fill(pingOneUsername);
+    await page.getByRole('textbox', { name: 'Password' }).fill(pingOnePassword);
+    await page.getByRole('button', { name: 'Sign On' }).click();
+
+    await page.waitForURL('http://localhost:8443/**');
+    expect(page.url()).toContain('code');
+    expect(page.url()).toContain('state');
+    await expect(page.locator('#User pre')).toContainText('demouser');
+    await expect(page.locator('#User pre')).toContainText('demouser@user.com');
+  });
+
+  test('login with invalid state fails with error', async ({ page }) => {
+    const { navigate } = asyncEvents(page);
+    await navigate('http://localhost:8443/?code=12345&state=abcxyz');
+    expect(page.url()).toBe('http://localhost:8443/?code=12345&state=abcxyz');
+
+    await expect(page.locator('#Error span')).toContainText('State mismatch');
+  });
+});

--- a/javascript/central-login-oidc-new/e2e/logout.spec.js
+++ b/javascript/central-login-oidc-new/e2e/logout.spec.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+import { test, expect } from '@playwright/test';
+import { asyncEvents } from './utils/async-events';
+import {
+  pingAmUsername,
+  pingAmPassword,
+  pingOneUsername,
+  pingOnePassword,
+} from './utils/demo-users';
+
+test.describe('Logout tests', () => {
+  test('PingOne login then logout', async ({ page }) => {
+    const { navigate, clickButton } = asyncEvents(page);
+    await navigate('http://localhost:8443/');
+    expect(page.url()).toBe('http://localhost:8443/');
+
+    let endSessionStatus, revokeStatus;
+    page.on('response', (response) => {
+      const responseUrl = response.url();
+      const status = response.ok();
+
+      if (responseUrl.includes('/as/idpSignoff?id_token_hint')) {
+        endSessionStatus = status;
+      }
+      if (responseUrl.includes('/revoke')) {
+        revokeStatus = status;
+      }
+    });
+
+    await clickButton('Login', 'https://apps.pingone.ca/');
+
+    await page.getByLabel('Username').fill(pingOneUsername);
+    await page.getByRole('textbox', { name: 'Password' }).fill(pingOnePassword);
+    await page.getByRole('button', { name: 'Sign On' }).click();
+
+    await page.waitForURL('http://localhost:8443/**');
+    expect(page.url()).toContain('code');
+    expect(page.url()).toContain('state');
+    await expect(page.getByRole('button', { name: 'Login' })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Sign Out' }).click();
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+
+    expect(endSessionStatus).toBeTruthy();
+    expect(revokeStatus).toBeTruthy();
+  });
+
+  test('PingAM login then logout', async ({ page }) => {
+    const { navigate, clickButton } = asyncEvents(page);
+    await navigate('http://localhost:8444/');
+    expect(page.url()).toBe('http://localhost:8444/');
+
+    let endSessionStatus, revokeStatus;
+    page.on('response', (response) => {
+      const responseUrl = response.url();
+      const status = response.ok();
+
+      if (responseUrl.includes('/endSession?id_token_hint')) {
+        endSessionStatus = status;
+      }
+      if (responseUrl.includes('/revoke')) {
+        revokeStatus = status;
+      }
+    });
+
+    await clickButton('Login', 'https://openam-sdks.forgeblocks.com/');
+
+    await page.getByLabel('User Name').fill(pingAmUsername);
+    await page.getByRole('textbox', { name: 'Password' }).fill(pingAmPassword);
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await page.waitForURL('http://localhost:8444/**');
+    expect(page.url()).toContain('code');
+    expect(page.url()).toContain('state');
+    await expect(page.getByRole('button', { name: 'Login' })).toBeHidden();
+
+    await page.getByRole('button', { name: 'Sign Out' }).click();
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+
+    expect(endSessionStatus).toBeTruthy();
+    expect(revokeStatus).toBeTruthy();
+  });
+
+  test('logout without tokens should error', async ({ page }) => {
+    const { navigate, clickButton } = asyncEvents(page);
+    await navigate('http://localhost:8443/');
+    expect(page.url()).toBe('http://localhost:8443/');
+
+    await clickButton('Login', 'https://apps.pingone.ca/');
+
+    await page.getByLabel('Username').fill(pingOneUsername);
+    await page.getByRole('textbox', { name: 'Password' }).fill(pingOnePassword);
+    await page.getByRole('button', { name: 'Sign On' }).click();
+
+    await page.waitForURL('http://localhost:8443/**');
+    expect(page.url()).toContain('code');
+    expect(page.url()).toContain('state');
+    await expect(page.getByRole('button', { name: 'Login' })).toBeHidden();
+
+    await page.evaluate(() => window.localStorage.clear());
+
+    await page.getByRole('button', { name: 'Sign Out' }).click();
+    await expect(page.locator('#Error span')).toContainText('Token_Error');
+  });
+});

--- a/javascript/central-login-oidc-new/e2e/utils/async-events.ts
+++ b/javascript/central-login-oidc-new/e2e/utils/async-events.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+export function asyncEvents(page) {
+  return {
+    async clickButton(text, endpoint) {
+      if (!endpoint)
+        throw new Error('Must provide endpoint argument, type string, e.g. "/authenticate"');
+      await Promise.all([
+        page.waitForResponse((response) => response.url().includes(endpoint)),
+        page.getByRole('button', { name: text }).click(),
+      ]);
+    },
+    async clickLink(text, endpoint) {
+      if (!endpoint)
+        throw new Error('Must provide endpoint argument, type string, e.g. "/authenticate"');
+      await Promise.all([
+        page.waitForResponse((response) => response.url().includes(endpoint)),
+        page.getByRole('link', { name: text }).click(),
+      ]);
+    },
+    async getTokens(origin, clientId) {
+      const webStorage = await page.context().storageState();
+
+      const originStorage = webStorage.origins.find((item) => item.origin === origin);
+      // Storage may not have any items
+      if (!originStorage) {
+        return null;
+      }
+      const clientIdStorage = originStorage?.localStorage.find((item) => item.name === clientId);
+
+      if (clientIdStorage && typeof clientIdStorage.value !== 'string' && !clientIdStorage.value) {
+        return null;
+      }
+      try {
+        return JSON.parse(clientIdStorage.value);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (e) {
+        return null;
+      }
+    },
+    async navigate(route) {
+      await page.goto(route, { waitUntil: 'networkidle' });
+    },
+    async pressEnter(endpoint) {
+      if (!endpoint)
+        throw new Error('Must provide endpoint argument, type string, e.g. "/authenticate"');
+      await Promise.all([
+        page.waitForResponse((response) => response.url().includes(endpoint)),
+        page.keyboard.press('Enter'),
+      ]);
+    },
+    async pressSpacebar(endpoint) {
+      if (!endpoint)
+        throw new Error('Must provide endpoint argument, type string, e.g. "/authenticate"');
+      await Promise.all([
+        page.waitForResponse((response) => response.url().includes(endpoint)),
+        page.keyboard.press(' '),
+      ]);
+    },
+  };
+}
+
+export async function verifyUserInfo(page, expect, type) {
+  const emailString = type === 'register' ? 'Email: test@auto.com' : 'Email: demo@user.com';
+  const nameString = 'Full name: Demo User';
+
+  const name = page.getByText(nameString);
+  const email = page.getByText(emailString);
+
+  // Just wait for one of them to be visible
+  await name.waitFor();
+
+  expect(await name.textContent()).toBe(nameString);
+  expect(await email.textContent()).toBe(emailString);
+}

--- a/javascript/central-login-oidc-new/e2e/utils/demo-users.ts
+++ b/javascript/central-login-oidc-new/e2e/utils/demo-users.ts
@@ -1,0 +1,13 @@
+/*
+ *
+ * Copyright © 2025 Ping Identity Corporation. All right reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ */
+
+export const pingAmUsername = 'sdkuser';
+export const pingAmPassword = 'password';
+export const pingOneUsername = 'demouser';
+export const pingOnePassword = 'U.QPDWEN47ZMyJhCDmhGLK*nr';

--- a/javascript/central-login-oidc-new/main.js
+++ b/javascript/central-login-oidc-new/main.js
@@ -16,8 +16,8 @@ const params = url.searchParams;
 const authCode = params.get('code');
 const state = params.get('state');
 
-const displayError = (errorMessage) => {
-  document.querySelector('#Error span').innerHTML = errorMessage;
+const displayError = (error) => {
+  document.querySelector('#Error span').innerHTML = JSON.stringify(error, null, 2);
   document.querySelector('#Error').classList.add('active');
 };
 

--- a/javascript/central-login-oidc-new/package.json
+++ b/javascript/central-login-oidc-new/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "devDependencies": {
     "vite": "^7.1.2"

--- a/javascript/central-login-oidc-new/playwright.config.js
+++ b/javascript/central-login-oidc-new/playwright.config.js
@@ -1,0 +1,63 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    trace: 'on',
+    ignoreHTTPSErrors: true,
+    headless: !!process.env.CI,
+  },
+  webServer: [
+    // PingOne client
+    {
+      command: 'npm run dev',
+      url: 'http://localhost:8443',
+      timeout: 120 * 1000,
+      reuseExistingServer: !process.env.CI,
+      cwd: './',
+      env: {
+        VITE_PORT: '8443',
+        VITE_WEB_OAUTH_CLIENT: '654b14e2-7cc5-4977-8104-c4113e43c537',
+        VITE_SCOPE: 'openid profile email revoke',
+        VITE_TIMEOUT: 3000,
+        VITE_WELLKNOWN_URL:
+          'https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration',
+      },
+      ignoreHTTPSErrors: true,
+    },
+
+    // PingAM client
+    {
+      command: 'npm run dev',
+      url: 'http://localhost:8444',
+      timeout: 120 * 1000,
+      reuseExistingServer: !process.env.CI,
+      cwd: './',
+      env: {
+        VITE_PORT: '8444',
+        VITE_WEB_OAUTH_CLIENT: 'WebOAuthClient',
+        VITE_SCOPE: 'openid profile email',
+        VITE_TIMEOUT: 3000,
+        VITE_WELLKNOWN_URL:
+          'https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration',
+      },
+      ignoreHTTPSErrors: true,
+    },
+  ],
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+  ],
+});

--- a/javascript/central-login-oidc-new/vite.config.js
+++ b/javascript/central-login-oidc-new/vite.config.js
@@ -1,31 +1,36 @@
 import * as path from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-export default defineConfig({
-  root: __dirname,
-  build: {
-    outDir: './dist',
-    reportCompressedSize: true,
-    target: 'esnext',
-    minify: false,
-    rollupOptions: {
-      input: {
-        main: path.resolve(__dirname, 'index.html'),
-      },
-      output: {
-        entryFileNames: 'main.js',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  const PORT = env.VITE_PORT || '8443';
+
+  return {
+    root: __dirname,
+    build: {
+      outDir: './dist',
+      reportCompressedSize: true,
+      target: 'esnext',
+      minify: false,
+      rollupOptions: {
+        input: {
+          main: path.resolve(__dirname, 'index.html'),
+        },
+        output: {
+          entryFileNames: 'main.js',
+        },
       },
     },
-  },
-  preview: {
-    port: 8443,
-  },
-  server: {
-    port: 8443,
-    headers: {
-      'Service-Worker-Allowed': '/',
-      'Service-Worker': 'script',
+    preview: {
+      port: PORT,
     },
-    strictPort: true,
-  },
+    server: {
+      port: PORT,
+      headers: {
+        'Service-Worker-Allowed': '/',
+        'Service-Worker': 'script',
+      },
+      strictPort: true,
+    },
+  };
 });


### PR DESCRIPTION
E2E tests for centralized login with OIDC client. This will be merged into the SDKS-4055-oidc-sample branch.
https://pingidentity.atlassian.net/browse/SDKS-4055

Note: CI fails because of the dependency on unreleased OIDC client but e2e tests pass locally