### PR TITLE
chore(reactjs-todo-journey): remove realm config

### DIFF
--- a/javascript/reactjs-todo-journey/.env.example
+++ b/javascript/reactjs-todo-journey/.env.example
@@ -7,7 +7,6 @@ VITE_DEVELOPMENT=true
 VITE_SCOPE='openid profile email'
 VITE_JOURNEY_LOGIN=Login
 VITE_JOURNEY_REGISTER=Registration
-VITE_REALM_PATH=alpha
 
 # VITE_INIT_PROTECT (optional) - bootstrap | journey
 # 'bootstrap' will initialize protect at app bootstrap time

--- a/javascript/reactjs-todo-journey/client/constants.js
+++ b/javascript/reactjs-todo-journey/client/constants.js
@@ -14,7 +14,6 @@ export const DEBUGGER = import.meta.env.VITE_DEBUGGER_OFF === 'false';
 export const JOURNEY_LOGIN = import.meta.env.VITE_JOURNEY_LOGIN;
 export const JOURNEY_REGISTER = import.meta.env.VITE_JOURNEY_REGISTER;
 export const WEB_OAUTH_CLIENT = import.meta.env.VITE_WEB_OAUTH_CLIENT;
-export const REALM_PATH = import.meta.env.VITE_REALM_PATH;
 export const SCOPE = import.meta.env.VITE_SCOPE;
 export const WELLKNOWN_URL = import.meta.env.VITE_WELLKNOWN_URL;
 export const INIT_PROTECT = import.meta.env.VITE_INIT_PROTECT;
@@ -42,5 +41,4 @@ export const CONFIG = {
   serverConfig: {
     wellknown: WELLKNOWN_URL,
   },
-  realmPath: REALM_PATH,
 };

--- a/javascript/reactjs-todo-journey/playwright.config.js
+++ b/javascript/reactjs-todo-journey/playwright.config.js
@@ -46,7 +46,6 @@ export default defineConfig({
           'https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration',
         VITE_SCOPE: 'profile openid email',
         VITE_WEB_OAUTH_CLIENT: 'WebOAuthClient',
-        VITE_REALM_PATH: 'alpha',
         VITE_PINGONE_ENV_ID: '02fb4743-189a-4bc7-9d6c-a919edfe6447',
       },
       ignoreHTTPSErrors: true,


### PR DESCRIPTION
Remove realm config. Realm is not needed for journey client config or anywhere else in the app. It is derived from wellknown automatically by sdk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal configuration by removing unused environment variable references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/sdk-sample-apps/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->