### PR TITLE
test(protect): unskip protect test to verify CI

### DIFF
--- a/javascript/reactjs-todo-login-widget/e2e/protect.spec.js
+++ b/javascript/reactjs-todo-login-widget/e2e/protect.spec.js
@@ -2,8 +2,7 @@ import { test, expect, describe } from '@playwright/test';
 import { displayName, password, username } from './utils/demo-user';
 
 describe('React - Login with Protect', () => {
-  // Skipped until Login Widget Protect bug is fixed. Login Widget should set data on callback.
-  test.skip('should succeed when initialized by callback', async ({ page }) => {
+  test('should succeed when initialized by callback', async ({ page }) => {
     const logs = [];
     page.on('console', async (msg) => {
       logs.push(msg.text());


### PR DESCRIPTION
Test-only PR. Removes test.skip from protect spec to verify CI passes. Do not merge — diagnostic for SDKS-5216.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled an end-to-end test covering successful initialization through a callback.
  * Verifies sign-in completion, welcome messaging, and initialization logging during the Protect journey.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->