### PR TITLE
chore(reactjs-todo-login-widget): bump login-widget to ^2.0.0

### DIFF
--- a/javascript/reactjs-todo-login-widget/package.json
+++ b/javascript/reactjs-todo-login-widget/package.json
@@ -39,7 +39,7 @@
     "webpack-dev-server": "^5.1.0"
   },
   "dependencies": {
-    "@forgerock/login-widget": "0.0.0-beta-20260723230753",
+    "@forgerock/login-widget": "^2.0.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3787,7 +3787,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@forgerock/login-widget": "0.0.0-beta-20260723230753",
+        "@forgerock/login-widget": "^2.0.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",
@@ -8386,9 +8386,9 @@
       }
     },
     "node_modules/@forgerock/login-widget": {
-      "version": "0.0.0-beta-20260723230753",
-      "resolved": "https://registry.npmjs.org/@forgerock/login-widget/-/login-widget-0.0.0-beta-20260723230753.tgz",
-      "integrity": "sha512-cG18D/mEnoqD0RCeic0j8bcEb4myRoHQ4BDDDU3n4KF1gmxu7jLA9UXj+bVg1UqikfnesFBm5htC8/A6EH5E/w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@forgerock/login-widget/-/login-widget-2.0.0.tgz",
+      "integrity": "sha512-yszvAfkvxh1Ugaz6YZgsk5QwMQTYcExSbomMgZDaxhvD+kxbVhKZaazzgZDKru0wGT5CCYuzhZWGcX7jz7vY1w==",
       "license": "MIT",
       "dependencies": {
         "@forgerock/journey-client": "^2.1.0",


### PR DESCRIPTION
## What

Bumps `@forgerock/login-widget` in the reactjs-todo-login-widget sample app from the placeholder beta build (`0.0.0-beta-20260723230753`) to `^2.0.0`.

## Why

PR #123 (login-widget 2.0 migration) merged to main pinned to an exact beta build as a placeholder because 2.0.0 was not yet released. This is the follow-up that swaps in the real release.

## Draft — blocked on release

Held as a draft because **`@forgerock/login-widget@2.0.0` is not published to npm yet** (release expected this week). Until then `npm install` will 404 and CI cannot pass.

Before marking ready for review:
- [x] 2.0.0 published to npm
- [x] Regenerate `package-lock.json` (`npm install`) and include it in this PR
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the login widget to the latest stable 2.0 release, improving compatibility and access to current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->