### PR TITLE
ci: block merge when PR carries 'do not merge' label

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,10 +2,18 @@ name: 'JS Continuous Integration'
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'javascript/**/*'
 
 jobs:
+  block-merge-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR carries "do not merge" label
+        run: |
+          echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | tr '[:upper:]' '[:lower:]' | grep -q '"do not merge"' && { echo "::error::Merge blocked: PR is labeled 'do not merge'."; exit 1; } || exit 0
+
   pr:
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Cross-repo CI gate. Adds a `block-merge-label` job that fails when a PR carries a "do not merge" label (case-insensitive), so it can be wired up as a required status check. Part of a 3-repo rollout (ping-javascript-sdk, forgerock-web-login-framework, sdk-sample-apps) — this PR covers `forgerock-web-login-framework`.

**Note:** this job must also be added as a required status check in this repo's GitHub branch protection settings — see Risks / Notes below. Adding the workflow job alone does not enforce merge blocking.

## Changes

### `.github/workflows/ci.yml`

- `pull_request` trigger added (`opened`, `synchronize`, `reopened`, `labeled`, `unlabeled`) alongside existing `push` trigger.
- New `block-merge-label` job: reads PR labels via `toJSON(github.event.pull_request.labels.*.name)`, lowercases with `tr`, greps for `"do not merge"`. Fails with `::error::` annotation if matched.
- Implemented as standalone job (not a step in existing `build`/`test-lint-storybook-build` jobs) so it can be required independently without coupling to full pipeline result.

## Tests

- No new automated tests — pure CI config change.
- Prettier-formatted, verified via `pnpm exec prettier --check`.

## How to test

### 1. Confirm block on labeled PR

Apply "do not merge" (or any casing variant) label to an open PR against this branch. Confirm `block-merge-label` job fails, error annotation shows "Merge blocked: PR is labeled 'do not merge'."

### 2. Confirm pass on unlabeled PR

Remove label (`unlabeled` event fires). Confirm job re-runs and passes.

## Risks / Notes

- Label text hardcoded as `do not merge`, case-insensitive. Repos using a different label string need manual sync — no config surface.
- Job needs no checkout/permissions — relies on default `pull_request` event payload.
- **Manual follow-up required:** `block-merge-label` must be added as a required status check in the repo's GitHub branch protection settings (Settings → Branches → main → require status checks) for this gate to actually block merging. Adding the job alone does not enforce anything.